### PR TITLE
Corrige la referencia de imagen en tarjetas de productos

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,9 +210,13 @@
                     productCard.className = 'product-card group relative flex flex-col cursor-pointer';
                     productCard.dataset.productId = product.id;
                     
+                    const imageSrc = Array.isArray(product.images) && product.images.length
+                        ? product.images[0]
+                        : product.image;
+
                     productCard.innerHTML = `
                         <div class="relative overflow-hidden rounded-lg">
-                            <img src="${product.image}" alt="${product.name}" class="w-full aspect-square object-cover transition-transform duration-500 group-hover:scale-105">
+                            <img src="${imageSrc}" alt="${product.name}" class="w-full aspect-square object-cover transition-transform duration-500 group-hover:scale-105">
                         </div>
                         <div class="pt-4 flex flex-col">
                             <h4 class="text-base font-semibold text-brand-dark">${product.name}</h4>


### PR DESCRIPTION
## Summary
- Usa la primera imagen disponible del arreglo `images` para cada tarjeta de producto, con `image` como respaldo

## Testing
- `npx --yes htmlhint index.html` *(falló: 403 Forbidden)*
- `npm test` *(falló: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e09a2516c832fad8c526c2587b1bd