### PR TITLE
Clarify optional JSON load for admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Catálogo Semilla en Flor
+
+Este repositorio contiene un catálogo de productos estático con un panel de administración simple.
+
+## Estrategia de carga de productos
+
+El panel de administración intenta cargar los productos almacenados en `localStorage`. Si no encuentra ninguno, tratará de recuperar un archivo `products.json` opcional con datos iniciales y lo guardará en el almacenamiento local para usos posteriores.

--- a/panel.html
+++ b/panel.html
@@ -116,7 +116,7 @@
                     if (storedProducts) {
                         products = JSON.parse(storedProducts);
                     } else {
-                        // Si no hay nada en localStorage, carga desde el JSON inicial
+                        // Si no hay productos almacenados, intenta cargar un archivo JSON opcional con datos iniciales
                         const response = await fetch('products.json');
                         products = await response.json();
                         localStorage.setItem('products', JSON.stringify(products));


### PR DESCRIPTION
## Summary
- Document product initialization strategy in admin panel.
- Add README explaining localStorage with optional JSON bootstrap.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e0ac45784832fa5b131efcf19cc3e